### PR TITLE
Fixed Infinite Empty Fields Being Added

### DIFF
--- a/custom-field-types/address-field-type.php
+++ b/custom-field-types/address-field-type.php
@@ -149,10 +149,10 @@ function cmb2_sanitize_address_field( $check, $meta_value, $object_id, $field_ar
 	}
 
 	foreach ( $meta_value as $key => $val ) {
-		$meta_value[ $key ] = array_map( 'sanitize_text_field', $val );
+		$meta_value[ $key ] = array_filter( array_map( 'sanitize_text_field', $val ) );
 	}
 
-	return $meta_value;
+	return array_filter($meta_value);
 }
 add_filter( 'cmb2_sanitize_address', 'cmb2_sanitize_address_field', 10, 5 );
 
@@ -163,9 +163,9 @@ function cmb2_types_esc_address_field( $check, $meta_value, $field_args, $field_
 	}
 
 	foreach ( $meta_value as $key => $val ) {
-		$meta_value[ $key ] = array_map( 'esc_attr', $val );
+		$meta_value[ $key ] = array_filter( array_map( 'esc_attr', $val ) );
 	}
 
-	return $meta_value;
+	return array_filter($meta_value);
 }
 add_filter( 'cmb2_types_esc_address', 'cmb2_types_esc_address_field', 10, 4 );


### PR DESCRIPTION
Added array_filter() to the field sanitization callback, and the esc
callback.  Without array_filter(), with every save a new empty input
field is added within each group.