### PR TITLE
Added new settings update notice to theme options page snippet

### DIFF
--- a/options-and-settings-pages/theme-options-cmb.php
+++ b/options-and-settings-pages/theme-options-cmb.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * CMB2 Theme Options
  * @version 0.1.0
@@ -6,15 +7,15 @@
 class Myprefix_Admin {
 
 	/**
- 	 * Option key, and option page slug
- 	 * @var string
- 	 */
+	 * Option key, and option page slug
+	 * @var string
+	 */
 	private $key = 'myprefix_options';
 
 	/**
- 	 * Options page metabox id
- 	 * @var string
- 	 */
+	 * Options page metabox id
+	 * @var string
+	 */
 	private $metabox_id = 'myprefix_option_metabox';
 
 	/**
@@ -46,6 +47,7 @@ class Myprefix_Admin {
 		add_action( 'admin_init', array( $this, 'init' ) );
 		add_action( 'admin_menu', array( $this, 'add_options_page' ) );
 		add_action( 'cmb2_admin_init', array( $this, 'add_options_page_metabox' ) );
+		add_action( 'cmb2_save_options-page_fields', array( $this, 'settings_notices' ), 10, 3 );
 	}
 
 
@@ -62,7 +64,7 @@ class Myprefix_Admin {
 	 * @since 0.1.0
 	 */
 	public function add_options_page() {
-		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, array( $this, 'admin_page_display' ) );
+		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, array( $this,	'admin_page_display' ) );
 
 		// Include CMB CSS in the head to avoid FOUT
 		add_action( "admin_print_styles-{$this->options_page}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
@@ -101,10 +103,10 @@ class Myprefix_Admin {
 		// Set our CMB2 fields
 
 		$cmb->add_field( array(
-			'name' => __( 'Test Text', 'myprefix' ),
-			'desc' => __( 'field description (optional)', 'myprefix' ),
-			'id'   => 'test_text',
-			'type' => 'text',
+			'name'    => __( 'Test Text', 'myprefix' ),
+			'desc'    => __( 'field description (optional)', 'myprefix' ),
+			'id'      => 'test_text',
+			'type'    => 'text',
 			'default' => 'Default Text',
 		) );
 
@@ -119,9 +121,28 @@ class Myprefix_Admin {
 	}
 
 	/**
+	 * Show Settings Notices
+	 *
+	 * @param $object_id
+	 * @param $updated
+	 * @param $cmb
+	 */
+	public function settings_notices( $object_id, $updated, $cmb ) {
+
+		if ( $object_id !== $this->key ) {
+			return;
+		}
+
+		add_settings_error( $this->key . '-notices', '', __( 'Settings updated.', 'myprefix' ), 'updated' );
+		settings_errors( $this->key . '-notices' );
+	}
+
+	/**
 	 * Public getter method for retrieving protected/private variables
 	 * @since  0.1.0
-	 * @param  string  $field Field to retrieve
+	 *
+	 * @param  string $field Field to retrieve
+	 *
 	 * @return mixed          Field value or exception is thrown
 	 */
 	public function __get( $field ) {
@@ -153,7 +174,9 @@ function myprefix_admin() {
 /**
  * Wrapper function around cmb2_get_option
  * @since  0.1.0
- * @param  string  $key Options array key
+ *
+ * @param  string $key Options array key
+ *
  * @return mixed        Option value
  */
 function myprefix_get_option( $key = '' ) {

--- a/options-and-settings-pages/theme-options-cmb.php
+++ b/options-and-settings-pages/theme-options-cmb.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * CMB2 Theme Options
  * @version 0.1.0
@@ -7,15 +6,15 @@
 class Myprefix_Admin {
 
 	/**
-	 * Option key, and option page slug
-	 * @var string
-	 */
+ 	 * Option key, and option page slug
+ 	 * @var string
+ 	 */
 	private $key = 'myprefix_options';
 
 	/**
-	 * Options page metabox id
-	 * @var string
-	 */
+ 	 * Options page metabox id
+ 	 * @var string
+ 	 */
 	private $metabox_id = 'myprefix_option_metabox';
 
 	/**
@@ -64,7 +63,7 @@ class Myprefix_Admin {
 	 * @since 0.1.0
 	 */
 	public function add_options_page() {
-		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, array( $this,	'admin_page_display' ) );
+		$this->options_page = add_menu_page( $this->title, $this->title, 'manage_options', $this->key, array( $this, 'admin_page_display' ) );
 
 		// Include CMB CSS in the head to avoid FOUT
 		add_action( "admin_print_styles-{$this->options_page}", array( 'CMB2_hookup', 'enqueue_cmb_css' ) );
@@ -103,10 +102,10 @@ class Myprefix_Admin {
 		// Set our CMB2 fields
 
 		$cmb->add_field( array(
-			'name'    => __( 'Test Text', 'myprefix' ),
-			'desc'    => __( 'field description (optional)', 'myprefix' ),
-			'id'      => 'test_text',
-			'type'    => 'text',
+			'name' => __( 'Test Text', 'myprefix' ),
+			'desc' => __( 'field description (optional)', 'myprefix' ),
+			'id'   => 'test_text',
+			'type' => 'text',
 			'default' => 'Default Text',
 		) );
 
@@ -136,13 +135,11 @@ class Myprefix_Admin {
 		add_settings_error( $this->key . '-notices', '', __( 'Settings updated.', 'myprefix' ), 'updated' );
 		settings_errors( $this->key . '-notices' );
 	}
-
+	
 	/**
 	 * Public getter method for retrieving protected/private variables
 	 * @since  0.1.0
-	 *
-	 * @param  string $field Field to retrieve
-	 *
+	 * @param  string  $field Field to retrieve
 	 * @return mixed          Field value or exception is thrown
 	 */
 	public function __get( $field ) {
@@ -174,9 +171,7 @@ function myprefix_admin() {
 /**
  * Wrapper function around cmb2_get_option
  * @since  0.1.0
- *
- * @param  string $key Options array key
- *
+ * @param  string  $key Options array key
  * @return mixed        Option value
  */
 function myprefix_get_option( $key = '' ) {


### PR DESCRIPTION
**Scenario:** When a user clicks the update button

**Problem:** No notice is shown letting the user know the fields have been updated when the page refreshes

**Solution:** Add generic settings updated message

![10-14-2015 1-50-45 pm](https://cloud.githubusercontent.com/assets/1571635/10497418/9f01b878-727a-11e5-87ff-310acabfc306.png)
