### PR TITLE
Reworked options classes into singletons

### DIFF
--- a/options-and-settings-pages/network-options-cmb.php
+++ b/options-and-settings-pages/network-options-cmb.php
@@ -30,12 +30,32 @@ class Myprefix_Network_Admin {
 	protected $options_page = '';
 
 	/**
+	 * Holds an instance of the project
+	 *
+	 * @Myprefix_Network_Admin
+	 **/
+	private static $instance = null;
+
+	/**
 	 * Constructor
 	 * @since 0.1.0
 	 */
-	public function __construct() {
+	private function __construct() {
 		// Set our title
 		$this->title = __( 'Network Settings', 'myprefix' );
+	}
+
+	/**
+	 * Get the running object
+	 *
+	 * @return Myprefix_Network_Admin
+	 **/
+	public static function get_instance() {
+		if( is_null( self::$instance ) ) {
+			self::$instance = new Myprefix_Network_Admin();
+			self::$instance->hooks();
+		}
+		return self::$instance;
 	}
 
 	/**
@@ -182,13 +202,7 @@ class Myprefix_Network_Admin {
  * @return Myprefix_Network_Admin object
  */
 function myprefix_network_admin() {
-	static $object = null;
-	if ( is_null( $object ) ) {
-		$object = new Myprefix_Network_Admin();
-		$object->hooks();
-	}
-
-	return $object;
+	return Myprefix_Network_Admin::get_instance();
 }
 
 /**
@@ -202,4 +216,4 @@ function myprefix_get_network_option( $key = '' ) {
 }
 
 // Get it started
-myprefix_admin();
+myprefix_network_admin();

--- a/options-and-settings-pages/theme-options-cmb.php
+++ b/options-and-settings-pages/theme-options-cmb.php
@@ -30,12 +30,32 @@ class Myprefix_Admin {
 	protected $options_page = '';
 
 	/**
+	 * Holds an instance of the object
+	 *
+	 * @var Myprefix_Admin
+	 **/
+	private static $instance = null;
+
+	/**
 	 * Constructor
 	 * @since 0.1.0
 	 */
-	public function __construct() {
+	private function __construct() {
 		// Set our title
 		$this->title = __( 'Site Options', 'myprefix' );
+	}
+
+	/**
+	 * Returns the running object
+	 *
+	 * @return Myprefix_Admin
+	 **/
+	public static function get_instance() {
+		if( is_null( self::$instance ) ) {
+			self::$instance = new Myprefix_Admin();
+			self::$instance->hooks();
+		}
+		return self::$instance;
 	}
 
 	/**
@@ -161,13 +181,7 @@ class Myprefix_Admin {
  * @return Myprefix_Admin object
  */
 function myprefix_admin() {
-	static $object = null;
-	if ( is_null( $object ) ) {
-		$object = new Myprefix_Admin();
-		$object->hooks();
-	}
-
-	return $object;
+	return Myprefix_Admin::get_instance();
 }
 
 /**


### PR DESCRIPTION
The functions used for getting the option classes are pretending that the
classes are singletons. This could lead to inconsistencies in how a project
runs if the options are accessed first by class and then by function. This
update will ensure they all act the same.