### PR TITLE
Fixed below title wordpress hook

### DIFF
--- a/misc/outputting-forms-outside-metaboxes.php
+++ b/misc/outputting-forms-outside-metaboxes.php
@@ -9,20 +9,20 @@
 function yourprefix_register_cmb2_fields() {
 
 	$cmb = new_cmb2_box( array(
-		'id'            => '_eedee_display_title',
+		'id'            => '_yourprefix_display_title',
 		'object_types'  => array( 'page' ),
 		//'title' => '', omit the 'title' field to keep the normal wp metabox from displaying
 	) );
 
 	$cmb->add_field( array(
 		'name' => 'Display title for this page?',
-		'id'   => '_eedee_display_title',
+		'id'   => '_yourprefix_display_title',
 		'type' => 'checkbox',
 	) );
 
 	$cmb->add_field( array(
 		'name' => 'A textarea',
-		'id'   => '_eedee_display_title_text',
+		'id'   => '_yourprefix_display_title_text',
 		'type' => 'textarea',
 	) );
 
@@ -35,10 +35,9 @@ add_action( 'cmb2_admin_init', 'yourprefix_register_cmb2_fields' );
  * @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L517-L523
  */
 function yourprefix_output_custom_mb_location() {
-	cmb2_get_metabox( '_eedee_display_title' )->show_form();
+	cmb2_get_metabox( '_yourprefix_display_title' )->show_form();
 }
 add_action( 'edit_form_after_title', 'yourprefix_output_custom_mb_location' );
-
 
 /**
  * More hooks in the post-editor screen as of 4.1

--- a/misc/outputting-forms-outside-metaboxes.php
+++ b/misc/outputting-forms-outside-metaboxes.php
@@ -32,6 +32,15 @@ add_action( 'cmb2_admin_init', 'yourprefix_register_cmb2_fields' );
 
 /**
  * Display checkbox metabox below title field
+ * @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L517-L523
+ */
+function yourprefix_output_custom_mb_location() {
+	cmb2_get_metabox( '_yourprefix_display_title' )->show_form();
+}
+add_action( 'edit_form_after_title', 'yourprefix_output_custom_mb_location' );
+
+/**
+ * Display checkbox metabox below wysiwyg editor field
  * @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L560-L567
  */
 function yourprefix_output_custom_mb_location() {

--- a/misc/outputting-forms-outside-metaboxes.php
+++ b/misc/outputting-forms-outside-metaboxes.php
@@ -9,20 +9,20 @@
 function yourprefix_register_cmb2_fields() {
 
 	$cmb = new_cmb2_box( array(
-		'id'            => '_yourprefix_display_title',
+		'id'            => '_eedee_display_title',
 		'object_types'  => array( 'page' ),
 		//'title' => '', omit the 'title' field to keep the normal wp metabox from displaying
 	) );
 
 	$cmb->add_field( array(
 		'name' => 'Display title for this page?',
-		'id'   => '_yourprefix_display_title',
+		'id'   => '_eedee_display_title',
 		'type' => 'checkbox',
 	) );
 
 	$cmb->add_field( array(
 		'name' => 'A textarea',
-		'id'   => '_yourprefix_display_title_text',
+		'id'   => '_eedee_display_title_text',
 		'type' => 'textarea',
 	) );
 
@@ -35,22 +35,20 @@ add_action( 'cmb2_admin_init', 'yourprefix_register_cmb2_fields' );
  * @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L517-L523
  */
 function yourprefix_output_custom_mb_location() {
-	cmb2_get_metabox( '_yourprefix_display_title' )->show_form();
+	cmb2_get_metabox( '_eedee_display_title' )->show_form();
 }
 add_action( 'edit_form_after_title', 'yourprefix_output_custom_mb_location' );
 
-/**
- * Display checkbox metabox below wysiwyg editor field
- * @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L560-L567
- */
-function yourprefix_output_custom_mb_location() {
-	cmb2_get_metabox( '_yourprefix_display_title' )->show_form();
-}
-add_action( 'edit_form_after_editor', 'yourprefix_output_custom_mb_location' );
 
 /**
  * More hooks in the post-editor screen as of 4.1
  */
+
+/**
+* Display checkbox metabox below wysiwyg editor field
+* @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L560-L567
+*/
+// add_action( 'edit_form_after_editor', 'yourprefix_output_custom_mb_location' );
 
 /**
  * @link https://github.com/WordPress/WordPress/blob/56d6682461be82da1a3bafc454dad2c9da451a38/wp-admin/edit-form-advanced.php#L217-L225


### PR DESCRIPTION
Fixed a wrong wordpress hook and added a new description for displaying metaboxes below title and below editor.

For the description _Display checkbox metabox below title field_ the wrong wordpress hook `'edit_form_after_editor'` was used. Changed to `'edit_form_after_title'` while leaving the other example as well with a corrected description.