### PR TITLE
Fix small errors in the class

### DIFF
--- a/widgets/widget-example.php
+++ b/widgets/widget-example.php
@@ -171,8 +171,10 @@ class CMB2_Widget_Boilerplate extends WP_Widget {
 			self::$shortcode
 		);
 
+		$widget_instance = new CMB2_Widget_Boilerplate;
+
 		$instance = shortcode_atts(
-			$this->defaults,
+			$widget_instance->defaults,
 			isset( $atts['instance'] ) ? (array) $atts['instance'] : array(),
 			self::$shortcode
 		);

--- a/widgets/widget-example.php
+++ b/widgets/widget-example.php
@@ -201,7 +201,7 @@ class CMB2_Widget_Boilerplate extends WP_Widget {
 			$widget .= '<div style="background-color:'. esc_attr( $instance['color'] ) .'">';
 
 			// Title
-			$widget .= ( $atts['title'] ) ? $atts['before_title'] . esc_html( $instance['title'] ) . $atts['after_title'] : '';
+			$widget .= ( $instance['title'] ) ? $atts['before_title'] . esc_html( $instance['title'] ) . $atts['after_title'] : '';
 
 			$widget .= wpautop( wp_kses_post( $instance['desc'] ) );
 


### PR DESCRIPTION
The static method get_widget was trying to access the non-static ``$this->defaults property``. I created an instance of the widget from the method to allow access to it, but I think it would be best to make the method non-static simply because that defeats the purpose.

Also there was a small error when displaying the widget. $atts['title'] should've been $instance['title']