### PR TITLE
Double array bugfix

### DIFF
--- a/custom-field-types/select-multiple-field-type.php
+++ b/custom-field-types/select-multiple-field-type.php
@@ -39,8 +39,8 @@ add_action( 'cmb2_render_select_multiple', 'cmb2_render_select_multiple_field_ty
  */
 function cmb2_sanitize_select_multiple_callback( $override_value, $value ) {
 	if ( is_array( $value ) ) {
-		foreach ( $value as $saved_value ) {
-			$value[] = sanitize_text_field( $saved_value );
+		foreach ( $value as $key => $saved_value ) {
+			$value[$key] = sanitize_text_field( $saved_value );
 		}
 
 		return $value;


### PR DESCRIPTION
There was a bug, when saved items appeared doubled. After sanitation, they were not added back, but rather added as new items to existing array.