### PR TITLE
A more obvious way to show how this action works

### DIFF
--- a/filters-and-actions/custom-css-for-specific-metabox.php
+++ b/filters-and-actions/custom-css-for-specific-metabox.php
@@ -29,4 +29,7 @@ function js_add_custom_css_for_metabox( $post_id, $cmb ) {
 	</style>
 	<?php
 }
-add_action( 'cmb2_after_post_form_custom_css_test', 'js_add_custom_css_for_metabox', 10, 2 );
+
+$object = 'post'; // post | term
+$cmb_id = 'custom_css_test'
+add_action( "cmb2_after_{object}_form_{$cmb_id}", 'js_add_custom_css_for_metabox', 10, 2 );


### PR DESCRIPTION
Just to show the user how this action works in a more obvious way.
It's separated in the object and the cmb id.

Other day I was trying to use it in a taxonomy page and i've realized i have to change the object to **term**