### PR TITLE
Updated auto-complete field type to use our production code

### DIFF
--- a/custom-field-types/autocomplete-field-type.php
+++ b/custom-field-types/autocomplete-field-type.php
@@ -4,11 +4,10 @@
  * Plugin Name: CMB2 Custom Field Type - Autocomplete
  * Description: Makes available an autocomplete custom field type.
  * Author: johnsonpaul1014
- * Version: 1.0.0
+ * Version: 1.1.0
  */
 
 /**
- *
  * It is a little complex but is very flexible, and it is a great option when you have
  * way too many things to put in a select.
  *
@@ -17,17 +16,13 @@
  *
  * There are two types available: options pre-built and one that uses a remote source.
  * To use the first option, simply build it like a select with the standard CMB2 "options" argument.
- * For a remote source, you will use the "source" argument that corresponds to an AJAX function.
- * Then, you pass in a "matching_function" to look up the selected autocomplete value using the
- * CMB2 field value.
  *
- * It can also be used as a repeatable field if a "repeatable_class" argument is passed when
- * constructing the field. This argument is necessary to allow for mapping the autocomplete
- * jQuery UI calls to the appropriate field.
+ * For a remote source, you will use the "source" argument that corresponds to an AJAX function.
+ * Then, you pass in a "mapping_function" to look up the selected autocomplete value using the
+ * CMB2 field value.
  *
  * The example fields in this plugin demonstrate all types: pre-built single field,
  * pre-built repeatable field, remote single field and remote repeatable field.
- *
  */
 
 /**
@@ -50,9 +45,9 @@ function autocomplete_cmb2_meta_boxes() {
 		'id' => $prefix.'related_fruit',
 		'type' => 'autocomplete',
 		'options' => array(
-			array('value' => 1, 'name' => 'Apple'),
-			array('value' => 2, 'name' => 'Orange'),
-			array('value' => 3, 'name' => 'Grape')
+			1 => 'Apple',
+			2 => 'Orange',
+			3 => 'Grape'
 		)
 	) );
 	$cmb->add_field( array(
@@ -61,11 +56,10 @@ function autocomplete_cmb2_meta_boxes() {
 		'id' => $prefix.'related_fruits',
 		'type' => 'autocomplete',
 		'repeatable' => true,
-		'repeatable_class' => 'related-fruits',
 		'options' => array(
-			array('value' => 1, 'name' => 'Apple'),
-			array('value' => 2, 'name' => 'Orange'),
-			array('value' => 3, 'name' => 'Grape')
+			1 => 'Apple',
+			2 => 'Orange',
+			3 => 'Grape'
 		)
 	) );
 	$cmb->add_field( array(
@@ -83,7 +77,6 @@ function autocomplete_cmb2_meta_boxes() {
 		'repeatable' => true,
 		'type' => 'autocomplete',
 		'source' => 'get_post_options',
-		'repeatable_class' => 'related-posts',
 		'mapping_function' => 'autocomplete_cmb2_get_post_title_from_id'
 	) );
 }
@@ -117,14 +110,26 @@ function autocomplete_cmb2_get_post_title_from_id($id) {
  */
 function autocomplete_cmb2_render_autocomplete($field_object, $escaped_value, $object_id, $object_type, $field_type_object) {
 
+	// Used to get the current one being rendered.  This isn't stored anywhere unfortunately.
+	static $current_field_nums = array();
+
+	$id = $field_object->args['id'];
+
+	if (isset($current_field_nums[$id])) {
+		$current_field_num = ++$current_field_nums[$id];
+	} else {
+		$current_field_num = $current_field_nums[$id] = 1;
+	}
+
+	// Get rid of notice.
+	if (is_array($field_object->escaped_value)) {
+		$field_object->escaped_value = '';
+	}
+
 	// Store the value in a hidden field.
 	echo $field_type_object->hidden();
 
-	if (isset($field_object->args['repeatable_class'])) {
-		$repeatable_class = $field_object->args['repeatable_class'];
-	}
-
-	$options = $field_object->options();
+	$options = $field_object->args['options'];
 
 	// Set up the options or source PHP variables.
 	if (empty($options)) {
@@ -136,105 +141,113 @@ function autocomplete_cmb2_render_autocomplete($field_object, $escaped_value, $o
 		if (empty($field_object->escaped_value)) {
 			$value = '';
 		} else {
-			foreach ($options as $option) {
-				if ($option['value'] == $field_object->escaped_value) {
-					$value = $option['name'];
+			foreach ($options as $option_value => $option_name) {
+				if ($option_value == $field_object->escaped_value) {
+					$value = $option_name;
 					break;
 				}
 			}
 		}
 	}
 
-	// Set up the autocomplete field.  Replace the '_' with '-' to not interfere with the ID from CMB2.
-	$id = str_replace('_', '-', $field_object->args['id']);
-
 	// Don't use the ID on repeatable elements as it won't change; use the class instead.
-	echo '<input size="50"'.(empty($repeatable_class) ? ' id="'.$id.'"' : '') . ' value="'.htmlspecialchars($value).'"'.
-		(!empty($repeatable_class) ? ' class="'.$repeatable_class.'"' : '').'/>';
+	echo '<input size="50" value="'.htmlspecialchars($value).'" class="'.$id.'-autocomplete"/>';
 
 	if (!$field_object->args['repeatable'] && isset($field_object->args['desc'])) {
 		echo '<p class="cmb2-metabox-description">'.$field_object->args['desc'].'</p>';
 	}
 
-	// Now, set up the script.
-	?>
-	<script>
-		jQuery(document).ready(function($) {
-			var options = [];
-			var nameToValue = [];
+	// Now, set up the script.  Only output it for the first field, because the rest can use the same options.
+	if ($current_field_num === 1) {
+		?>
+		<script>
+			jQuery(document).ready(function($) {
+				var options = [];
+				var nameToValue = [];
 
-			<?php
+				<?php
 
-			if (!empty($options)) {
-				foreach ($options as $option) {
-					echo "options.push('".addcslashes($option['name'], "'")."');\r\n";
-					echo "nameToValue['".addcslashes($option['name'], "'")."'] = '".$option['value']."';\r\n";
-				}
-			}
-
-			if (!empty($repeatable_class)) { ?>
-			$('.<?php echo $repeatable_class; ?>').each(function(i, el) {
-				if (typeof $(this).data('ui-autocomplete') === 'undefined') {
-						$(this).autocomplete({
-			<?php } else { ?>
-			$('#<?php echo $id; ?>').autocomplete({
-			<?php } ?>
-				source: <?php if (empty($options)) { ?>
-					function(request, response) {
-						$.ajax(
-							{url: ajaxurl,
-							 data: {
-								action: '<?php echo $source; ?>',
-								q: request.term
-							 },
-							 success: function(data) {
-
-								// Set up options and name to value for this returned set.
-								var values = $.parseJSON(data);
-								options = [];
-								nameToValue = [];
-
-								for (optionI in values) {
-									var option = values[optionI];
-									options.push(option.name);
-									nameToValue[option.name] = option.value;
-								}
-
-								response(options);
-							}
-						 });
-						} <?php } else {
-							echo 'options';
-						} ?>
-			});
-
-			// Also set up a blur function to update the ID.
-			$(<?php echo empty($repeatable_class) ? "'#".$id."'" : 'this'; ?>).blur(function(e) {
-				$(this).prev('input').val(nameToValue[$(this).val()]);
-			});
-
-			<?php
-
-			if (!empty($repeatable_class)) { ?>
+				if (!empty($options)) {
+					foreach ($options as $option_value => $option_name) {
+						echo "options.push('".addcslashes($option_name, "'")."');\r\n";
+						echo "nameToValue['".addcslashes($option_name, "'")."'] = '".$option_value."';\r\n";
 					}
-				});
-			<?php
-			}
-			?>
-		});
-	</script>
-	<?php
+				}
+
+				// Bind to the parent grouping a focus in event on the inputs to build the autocompletes if they aren't there in the
+				// repeatable case.
+				if ($field_object->args['repeatable']) { ?>
+				$('.<?php echo $id; ?>-autocomplete').eq(0).parents('.cmb-repeat-table').on('focusin', 'input', function() {
+					if (typeof($(this).data('ui-autocomplete')) === 'undefined') {
+						<?php
+						} else { // Non repeatable ?>
+						$('.<?php echo $id; ?>-autocomplete').each(function(i, el) {
+							<?php
+							}
+							?>
+							$(this).autocomplete({
+								delay: 500,
+								source: <?php if (empty($options)) { ?>
+									function(request, response) {
+										$.ajax(
+											{url: ajaxurl,
+												data: {
+													action: '<?php echo $source; ?>',
+													nonce: '<?php echo wp_create_nonce($source); ?>',
+													q: request.term
+												},
+												success: function(data) {
+
+													// Set up options and name to value for this returned set.
+													var values = $.parseJSON(data);
+													options = [];
+													nameToValue = [];
+
+													for (optionValue in values) {
+														var option = optionValue;
+														options.push(values[optionValue]);
+														nameToValue[values[optionValue]] = optionValue;
+													}
+
+													response(options);
+												}
+											});
+									} <?php } else {
+									echo 'options';
+								} ?>
+							});
+
+							// Also set up a blur function to update the ID.
+							$(this).blur(function(e) {
+								if (typeof nameToValue[$(this).val()] === 'undefined') {
+									$(this).prev('input').val('').trigger('change');
+								} else {
+									$(this).prev('input').val(nameToValue[$(this).val()]).trigger('change');
+								}
+							});
+							<?php
+
+							// Finish the if block.
+							if ($field_object->args['repeatable']) {
+								echo '}';
+							}
+
+							?>
+						});
+					});
+		</script>
+		<?php
+	}
 }
 
 /**
  * Gets post options using a post type
  *
  * @param mixed $post_type array or string of post type(s)
- * @param boolean $include_empty whether or not to include an empty value
  * @param string $like_test used to query for posts like a certain value
  * @return array
  */
-function autocomplete_cmb2_get_post_options_using_post_type($post_type, $include_empty = false, $like_test = '%%') {
+function autocomplete_cmb2_get_post_options_using_post_type($post_type, $like_test = '%%') {
 
 	// Use a query instead of "get_posts" to save on a ton of memory.
 	global $wpdb;
@@ -252,17 +265,8 @@ function autocomplete_cmb2_get_post_options_using_post_type($post_type, $include
     ORDER BY post_title ASC
  	", $like_test), OBJECT);
 
-	if ($include_empty) {
-		$post_options = array(array('name' => '--- Select ---', 'value' => ''));
-	} else {
-		$post_options = array();
-	}
-
 	foreach ($posts as $post) {
-		$post_options[] = array(
-			 'name' => $post->post_title,
-			 'value' => $post->ID
-		);
+		$post_options[$post->ID] = $post->post_title;
 	}
 
 	return $post_options;
@@ -281,7 +285,7 @@ function autocomplete_cmb2_admin_enqueue_scripts() {
  * Gets the post options in JSON format for the autocomplete
  */
 function autocomplete_cmb2_get_post_autocomplete_options() {
-	die(json_encode(autocomplete_cmb2_get_post_options_using_post_type('post', false, '%'.$_GET['q'].'%')));
+	die(json_encode(autocomplete_cmb2_get_post_options_using_post_type('post', '%'.$_GET['q'].'%')));
 }
 
 add_action('cmb2_render_autocomplete', 'autocomplete_cmb2_render_autocomplete', 10, 5);


### PR DESCRIPTION
I have updated this snippet to use our production code.  Note that the options for the auto-complete now follow the updated CMB2 style.  There were also some other tweaks that were made so the repeatable_class argument is no longer necessary.