### PR TITLE
Otherwise only one of multiple frontend forms is working.

### DIFF
--- a/front-end/cmb2-front-end-submit.php
+++ b/front-end/cmb2-front-end-submit.php
@@ -154,7 +154,7 @@ add_shortcode( 'cmb-frontend-form', 'wds_do_frontend_form_submission_shortcode' 
 function wds_handle_frontend_new_post_form_submission() {
 
 	// If no form submission, bail
-	if ( empty( $_POST ) || ! isset( $_POST['submit-cmb'], $_POST['object_id'] ) ) {
+	if ( empty( $_POST ) || ! isset( $_POST['submit-cmb'], $_POST['object_id'] ) || $_POST['object_id'] != 'fake-oject-id' ) {
 		return false;
 	}
 


### PR DESCRIPTION
When I have multiple copies of this function* - each for one frontend form - this is necessary modification.

\* like:
wds_handle_frontend_new_post_form_submission()
wds2_handle_frontend_new_post_form_submission()
…